### PR TITLE
Add logging for LLM interactions

### DIFF
--- a/llmcode/logging_utils.py
+++ b/llmcode/logging_utils.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import json
+import os
+import datetime
+import pathlib
+import threading
+
+_lock = threading.Lock()
+
+LOG_DIR_DEFAULT = pathlib.Path("logs")
+
+
+def log_prompt(
+    prompt: str,
+    response: str,
+    *,
+    model: str,
+    temperature: float,
+    system_prompt: str | None,
+) -> None:
+    if os.getenv("LLMCODE_NO_LOG"):
+        return
+    log_dir = pathlib.Path(os.getenv("LLMCODE_LOG_DIR", LOG_DIR_DEFAULT))
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    fname = f"llmcode_{datetime.date.today():%Y-%m-%d}.jsonl"
+    record = {
+        "ts": datetime.datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "model": model,
+        "temperature": temperature,
+        "system_prompt": system_prompt,
+        "prompt": prompt,
+        "response": response,
+    }
+    line = json.dumps(record, ensure_ascii=False)
+    with _lock:
+        with open(log_dir / fname, "a", encoding="utf-8") as f:
+            f.write(line + "\n")

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,95 @@
+import json
+import datetime
+import types
+from pathlib import Path
+
+import pytest
+
+from llmcode import logging_utils
+from tests.test_llm_backend import load_llms
+
+
+def _patch_datetime(monkeypatch):
+    class DDate(datetime.date):
+        @classmethod
+        def today(cls):
+            return cls(2001, 1, 2)
+
+    class DDateTime(datetime.datetime):
+        @classmethod
+        def utcnow(cls):
+            return cls(2001, 1, 2, 3, 4, 5)
+
+    monkeypatch.setattr(
+        logging_utils,
+        "datetime",
+        types.SimpleNamespace(date=DDate, datetime=DDateTime),
+    )
+
+
+@pytest.mark.usefixtures("monkeypatch")
+def test_log_prompt_creates_file(tmp_path, monkeypatch):
+    _patch_datetime(monkeypatch)
+    monkeypatch.setenv("LLMCODE_LOG_DIR", str(tmp_path))
+    logging_utils.log_prompt("p", "r", model="m", temperature=0.1, system_prompt="s")
+    path = tmp_path / "llmcode_2001-01-02.jsonl"
+    data = [json.loads(path.read_text(encoding="utf-8"))]
+    assert data == [
+        {
+            "ts": "2001-01-02T03:04:05Z",
+            "model": "m",
+            "temperature": 0.1,
+            "system_prompt": "s",
+            "prompt": "p",
+            "response": "r",
+        }
+    ]
+
+
+def test_log_prompt_no_log_env(tmp_path, monkeypatch):
+    _patch_datetime(monkeypatch)
+    monkeypatch.setenv("LLMCODE_LOG_DIR", str(tmp_path))
+    monkeypatch.setenv("LLMCODE_NO_LOG", "1")
+    logging_utils.log_prompt("p", "r", model="m", temperature=0.1, system_prompt="s")
+    assert not (tmp_path / "llmcode_2001-01-02.jsonl").exists()
+
+
+def test_query_llm_logs(monkeypatch):
+    llms = load_llms(monkeypatch)
+
+    class DummyBackend:
+        def __init__(self, api_key):
+            self.api_key = api_key
+
+        def query(self, prompt, **kwargs):
+            return f"{prompt}|{self.api_key}"
+
+    monkeypatch.setattr(llms, "OpenAIBackend", DummyBackend)
+    monkeypatch.setenv("OPENAI_API_KEY", "KEY")
+
+    records = []
+
+    def fake_log(prompt, response, *, model, temperature, system_prompt):
+        records.append(
+            {
+                "prompt": prompt,
+                "response": response,
+                "model": model,
+                "temperature": temperature,
+                "system_prompt": system_prompt,
+            }
+        )
+
+    monkeypatch.setattr(llms, "log_prompt", fake_log)
+
+    llms.query_LLM("hi", model="m", temperature=0.5, system_message="sys")
+
+    assert records == [
+        {
+            "prompt": "hi",
+            "response": "hi|KEY",
+            "model": "m",
+            "temperature": 0.5,
+            "system_prompt": "sys",
+        }
+    ]


### PR DESCRIPTION
## Summary
- implement a thread-safe JSON-lines logger in `llmcode/logging_utils.py`
- log each prompt/response pair in the `query_LLM` helpers
- cover logging behaviour with new unit tests

## Testing
- `venv/bin/python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841cae34b188332bfc7561149c35e7c