### PR TITLE
Add hierarchical kappa metric

### DIFF
--- a/llmcode/hier.py
+++ b/llmcode/hier.py
@@ -1,0 +1,31 @@
+"""Utilities for hierarchical code paths."""
+
+from __future__ import annotations
+
+
+def code_to_path(code: str, delim: str = " > ") -> list[str]:
+    """Split a hierarchical code string into a list of segments."""
+    return [segment.strip() for segment in code.split(delim)]
+
+
+def build_code_tree(codes: list[str], delim: str = " > ") -> dict:
+    """Build a nested dictionary representing the hierarchy of codes."""
+    tree: dict[str, dict] = {}
+    for code in codes:
+        path = code_to_path(code, delim=delim)
+        node = tree
+        for segment in path:
+            node = node.setdefault(segment, {})
+    return tree
+
+
+def common_ancestor_depth(a: str, b: str, delim: str = " > ") -> int:
+    """Return the number of matching path segments from the root."""
+    path_a = code_to_path(a, delim=delim)
+    path_b = code_to_path(b, delim=delim)
+    depth = 0
+    for seg_a, seg_b in zip(path_a, path_b):
+        if seg_a != seg_b:
+            break
+        depth += 1
+    return depth

--- a/tests/test_hierarchical_metrics.py
+++ b/tests/test_hierarchical_metrics.py
@@ -1,0 +1,43 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+from numpy.testing import assert_allclose
+
+# Prepare lightweight llmcode package
+package = types.ModuleType("llmcode")
+package.__path__ = [str(Path(__file__).resolve().parents[1] / "llmcode")]
+sys.modules.setdefault("llmcode", package)
+
+spec = importlib.util.spec_from_file_location(
+    "llmcode.metrics", Path(__file__).resolve().parents[1] / "llmcode" / "metrics.py"
+)
+metrics = importlib.util.module_from_spec(spec)
+sys.modules["llmcode.metrics"] = metrics
+spec.loader.exec_module(metrics)
+
+from llmcode.metrics import cohen_kappa_hier
+
+
+def test_full_match():
+    a = ["Parent > Child1", "Other > Sub"]
+    b = ["Parent > Child1", "Other > Sub"]
+    assert_allclose(cohen_kappa_hier(a, b), 1.0, rtol=1e-6)
+
+
+def test_sibling_match():
+    a = ["Parent > A1", "Parent > A1"]
+    b = ["Parent > A2", "Parent > A2"]
+    sibling_credit = 0.5
+    assert_allclose(
+        cohen_kappa_hier(a, b, sibling_credit=sibling_credit),
+        sibling_credit,
+        rtol=1e-6,
+    )
+
+
+def test_no_commonality():
+    a = ["A > A1", "B > B1"]
+    b = ["C > C1", "D > D1"]
+    assert_allclose(cohen_kappa_hier(a, b), 0.0, rtol=1e-6)


### PR DESCRIPTION
## Summary
- implement basic hierarchy utils `code_to_path`, `build_code_tree`, `common_ancestor_depth`
- implement `cohen_kappa_hier` with sibling weighting
- test hierarchical kappa for matching, sibling and unmatched cases

## Testing
- `PYTHONPATH=venv/lib/python3.12/site-packages:. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841da11d1d48332b96317251818bc72